### PR TITLE
Add client execution timeout and add test

### DIFF
--- a/src/unitycatalog/ai/databricks.py
+++ b/src/unitycatalog/ai/databricks.py
@@ -37,6 +37,7 @@ DEFAULT_EXECUTE_FUNCTION_ARGS = {
     "row_limit": 100,
     "byte_limit": 4096,
 }
+UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT = "UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT"
 
 _logger = logging.getLogger(__name__)
 
@@ -410,7 +411,9 @@ class DatabricksFunctionClient(BaseFunctionClient):
                 _logger.info("Retrying to get statement execution status...")
                 wait_time = 0
                 retry_cnt = 0
-                client_execution_timeout = int(os.environ.get("CLIENT_EXECUTION_TIMEOUT", "120"))
+                client_execution_timeout = int(
+                    os.environ.get(UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "120")
+                )
                 while wait_time < client_execution_timeout:
                     wait = min(2**retry_cnt, client_execution_timeout - wait_time)
                     time.sleep(wait)
@@ -424,7 +427,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
                     return FunctionExecutionResult(
                         error=f"Statement execution is still pending after {wait_time} "
                         "seconds. Please try increase the wait_timeout argument for executing "
-                        "the function or increase CLIENT_EXECUTION_TIMEOUT environment "
+                        f"the function or increase {UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT} environment "
                         "variable for increasing retrying time."
                     )
             if response.status is None:

--- a/src/unitycatalog/ai/databricks.py
+++ b/src/unitycatalog/ai/databricks.py
@@ -38,6 +38,7 @@ DEFAULT_EXECUTE_FUNCTION_ARGS = {
     "byte_limit": 4096,
 }
 UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT = "UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT"
+DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT = "120"
 
 _logger = logging.getLogger(__name__)
 
@@ -412,7 +413,10 @@ class DatabricksFunctionClient(BaseFunctionClient):
                 wait_time = 0
                 retry_cnt = 0
                 client_execution_timeout = int(
-                    os.environ.get(UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "120")
+                    os.environ.get(
+                        UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT,
+                        DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT,
+                    )
                 )
                 while wait_time < client_execution_timeout:
                     wait = min(2**retry_cnt, client_execution_timeout - wait_time)
@@ -426,9 +430,9 @@ class DatabricksFunctionClient(BaseFunctionClient):
                 if response.status and job_pending(response.status.state):
                     return FunctionExecutionResult(
                         error=f"Statement execution is still pending after {wait_time} "
-                        "seconds. Please try increase the wait_timeout argument for executing "
+                        "seconds. Please increase the wait_timeout argument for executing "
                         f"the function or increase {UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT} environment "
-                        "variable for increasing retrying time."
+                        f"variable for increasing retrying time, default value is {DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT} seconds."
                     )
             if response.status is None:
                 return FunctionExecutionResult(error=f"Statement execution failed: {response}")

--- a/src/unitycatalog/ai/databricks.py
+++ b/src/unitycatalog/ai/databricks.py
@@ -1,35 +1,35 @@
+import base64
 import inspect
 import json
-import base64
 import logging
+import os
 import re
 import time
 from dataclasses import dataclass
+from decimal import Decimal
 from io import StringIO
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
-from decimal import Decimal
 
 from typing_extensions import override
 
 from unitycatalog.ai.client import BaseFunctionClient, FunctionExecutionResult
+from unitycatalog.ai.paged_list import PagedList
 from unitycatalog.ai.utils import (
     column_type_to_python_type,
     convert_timedelta_to_interval_str,
     is_time_type,
-    validate_param,
     validate_full_function_name,
+    validate_param,
 )
-from unitycatalog.ai.paged_list import PagedList
 
 if TYPE_CHECKING:
     from databricks.sdk import WorkspaceClient
-    from databricks.sdk.service.sql import StatementState
     from databricks.sdk.service.catalog import (
         CreateFunction,
         FunctionInfo,
         FunctionParameterInfo,
     )
-    from databricks.sdk.service.sql import StatementParameterListItem
+    from databricks.sdk.service.sql import StatementParameterListItem, StatementState
 
 EXECUTE_FUNCTION_ARG_NAME = "__execution_args__"
 DEFAULT_EXECUTE_FUNCTION_ARGS = {
@@ -189,7 +189,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
                     ) from e
             elif self.cluster_id:
                 _logger.info("Using databricks cluster to create function.")
-                from databricks.sdk.service.compute import Language, ContextStatus, CommandStatus
+                from databricks.sdk.service.compute import CommandStatus, ContextStatus, Language
 
                 context_result = self.client._command_execution.create_and_wait(
                     cluster_id=self.cluster_id, language=Language.SQL
@@ -408,17 +408,24 @@ class DatabricksFunctionClient(BaseFunctionClient):
             if response.status and job_pending(response.status.state) and response.statement_id:
                 statement_id = response.statement_id
                 _logger.info("Retrying to get statement execution status...")
-                max_retries = 6
-                for retry_cnt in range(1, max_retries + 1):
-                    time.sleep(2**retry_cnt)
+                wait_time = 0
+                retry_cnt = 0
+                client_execution_timeout = int(os.environ.get("CLIENT_EXECUTION_TIMEOUT", "120"))
+                while wait_time < client_execution_timeout:
+                    wait = min(2**retry_cnt, client_execution_timeout - wait_time)
+                    time.sleep(wait)
                     _logger.info(f"Retry times: {retry_cnt}")
                     response = self.client.statement_execution.get_statement(statement_id)
                     if response.status is None or not job_pending(response.status.state):
                         break
+                    wait_time += wait
+                    retry_cnt += 1
                 if response.status and job_pending(response.status.state):
                     return FunctionExecutionResult(
-                        error=f"Statement execution is still pending after {max_retries} times. "
-                        "Please try increase the wait_timeout argument for executing the function."
+                        error=f"Statement execution is still pending after {wait_time} "
+                        "seconds. Please try increase the wait_timeout argument for executing "
+                        "the function or increase CLIENT_EXECUTION_TIMEOUT environment "
+                        "variable for increasing retrying time."
                     )
             if response.status is None:
                 return FunctionExecutionResult(error=f"Statement execution failed: {response}")
@@ -472,6 +479,12 @@ class DatabricksFunctionClient(BaseFunctionClient):
 
         # TODO: support serverless
         raise ValueError("warehouse_id is required for executing UC functions in Databricks")
+
+    @override
+    def validate_input_params(self, input_params: Any, parameters: Dict[str, Any]) -> None:
+        super().validate_input_params(
+            input_params, {k: v for k, v in parameters.items() if k != EXECUTE_FUNCTION_ARG_NAME}
+        )
 
     @override
     def to_dict(self):

--- a/src/unitycatalog/ai/databricks.py
+++ b/src/unitycatalog/ai/databricks.py
@@ -37,7 +37,7 @@ DEFAULT_EXECUTE_FUNCTION_ARGS = {
     "row_limit": 100,
     "byte_limit": 4096,
 }
-UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT = "UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT"
+UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT = "UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT"
 
 _logger = logging.getLogger(__name__)
 
@@ -412,7 +412,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
                 wait_time = 0
                 retry_cnt = 0
                 client_execution_timeout = int(
-                    os.environ.get(UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "120")
+                    os.environ.get(UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "120")
                 )
                 while wait_time < client_execution_timeout:
                     wait = min(2**retry_cnt, client_execution_timeout - wait_time)
@@ -427,7 +427,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
                     return FunctionExecutionResult(
                         error=f"Statement execution is still pending after {wait_time} "
                         "seconds. Please try increase the wait_timeout argument for executing "
-                        f"the function or increase {UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT} environment "
+                        f"the function or increase {UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT} environment "
                         "variable for increasing retrying time."
                     )
             if response.status is None:

--- a/tests/ai/test_databricks_client.py
+++ b/tests/ai/test_databricks_client.py
@@ -41,12 +41,11 @@ _logger = logging.getLogger(__name__)
 # 2. python 3.9 with databricks-sdk, with cluster_id
 @pytest.fixture
 def client() -> DatabricksFunctionClient:
-    # with mock.patch(
-    #     "unitycatalog.ai.databricks.get_default_databricks_workspace_client",
-    #     return_value=mock.Mock(),
-    # ):
-    #     return DatabricksFunctionClient(warehouse_id="warehouse_id", cluster_id="cluster_id")
-    return DatabricksFunctionClient(warehouse_id="63f9f8ed4cedd92b")
+    with mock.patch(
+        "unitycatalog.ai.databricks.get_default_databricks_workspace_client",
+        return_value=mock.Mock(),
+    ):
+        return DatabricksFunctionClient(warehouse_id="warehouse_id", cluster_id="cluster_id")
 
 
 def random_func_name():

--- a/tests/ai/test_databricks_client.py
+++ b/tests/ai/test_databricks_client.py
@@ -1,13 +1,13 @@
 import base64
 import datetime
 import logging
+import time
 import uuid
 from contextlib import contextmanager
 from decimal import Decimal
 from typing import Any, Callable, Dict, List, NamedTuple
 from unittest import mock
 
-import time
 import pytest
 from databricks.sdk.service.catalog import (
     ColumnTypeName,
@@ -21,13 +21,14 @@ from databricks.sdk.service.catalog import (
     FunctionParameterInfos,
 )
 
+from tests.helper_functions import requires_databricks
 from unitycatalog.ai.databricks import (
     DEFAULT_EXECUTE_FUNCTION_ARGS,
     EXECUTE_FUNCTION_ARG_NAME,
+    UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT,
     DatabricksFunctionClient,
     extract_function_name,
 )
-from tests.helper_functions import requires_databricks
 
 CATALOG = "ml"
 SCHEMA = "serena_uc_test"
@@ -265,7 +266,7 @@ def test_create_and_execute_function(
 
 @requires_databricks
 def test_execute_function_with_timeout(client: DatabricksFunctionClient, monkeypatch):
-    monkeypatch.setenv("CLIENT_EXECUTION_TIMEOUT", "5")
+    monkeypatch.setenv(UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "5")
     with generate_func_name_and_cleanup(client) as func_name:
         full_func_name = f"{CATALOG}.{SCHEMA}.{func_name}"
         sql_body = f"""CREATE FUNCTION {full_func_name}()

--- a/tests/ai/test_databricks_client.py
+++ b/tests/ai/test_databricks_client.py
@@ -25,7 +25,7 @@ from tests.helper_functions import requires_databricks
 from unitycatalog.ai.databricks import (
     DEFAULT_EXECUTE_FUNCTION_ARGS,
     EXECUTE_FUNCTION_ARG_NAME,
-    UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT,
+    UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT,
     DatabricksFunctionClient,
     extract_function_name,
 )
@@ -266,7 +266,7 @@ def test_create_and_execute_function(
 
 @requires_databricks
 def test_execute_function_with_timeout(client: DatabricksFunctionClient, monkeypatch):
-    monkeypatch.setenv(UNITICATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "5")
+    monkeypatch.setenv(UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "5")
     with generate_func_name_and_cleanup(client) as func_name:
         full_func_name = f"{CATALOG}.{SCHEMA}.{func_name}"
         sql_body = f"""CREATE FUNCTION {full_func_name}()

--- a/tests/ai/test_databricks_client.py
+++ b/tests/ai/test_databricks_client.py
@@ -265,7 +265,7 @@ def test_create_and_execute_function(
             assert result.value == function_sample.output
 
 
-# @requires_databricks
+@requires_databricks
 def test_execute_function_with_timeout(client: DatabricksFunctionClient, monkeypatch):
     monkeypatch.setenv(UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "5")
     with generate_func_name_and_cleanup(client) as func_name:


### PR DESCRIPTION
Add CLIENT_EXECUTION_TIMEOUT for controlling the client side wait time for executing functions.
Note: the default wait_timeout in SQL execution side is 30s, so the wait time on the execute_statement is controlled by wait_timeout parameter; while CLIENT_EXECUTION_TIMEOUT controls how long we should keep retrying for getting a response.
TODO: we should add an example explaining this in a follow-up PR.