### PR TITLE
Support serverless execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ assert result.value == "some_string"
 ```
 
 #### Reminders
-- If the function contains `DECIMAL` type parameter, it is converted to python `float` for execution, and this conversion mayb lose precision.
+- If the function contains `DECIMAL` type parameter, it is converted to python `float` for execution, and this conversion may lose precision.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,6 @@ Parameters passed into execute_function must be a dictionary that maps to the in
 result = client.execute_function(full_func_name, {"s": "some_string"})
 assert result.value == "some_string"
 ```
+
+#### Reminders
+- If the function contains `DECIMAL` type parameter, it is converted to python `float` for execution, and this conversion mayb lose precision.

--- a/src/unitycatalog/ai/databricks.py
+++ b/src/unitycatalog/ai/databricks.py
@@ -15,12 +15,11 @@ from typing_extensions import override
 from unitycatalog.ai.client import BaseFunctionClient, FunctionExecutionResult
 from unitycatalog.ai.paged_list import PagedList
 from unitycatalog.ai.utils.type_utils import (
-    convert_timedelta_to_interval_str,
     column_type_to_python_type,
+    convert_timedelta_to_interval_str,
     is_time_type,
 )
 from unitycatalog.ai.utils.validation_utils import validate_full_function_name, validate_param
-
 
 if TYPE_CHECKING:
     from databricks.sdk import WorkspaceClient
@@ -636,10 +635,6 @@ def get_execute_function_sql_stmt(
                     if param_info.type_name == ColumnTypeName.DECIMAL and isinstance(
                         param_value, Decimal
                     ):
-                        _logger.warning(
-                            f"Param {param_info.name} has decimal value {param_value}, it is converted to float "
-                            "for execution, please note that this conversion may lose precision."
-                        )
                         param_value = float(param_value)
                     arg_clause += f":{param_info.name}"
                     output_params.append(
@@ -704,12 +699,8 @@ def get_execute_function_sql_command(function: "FunctionInfo", parameters: Dict[
                     if param_info.type_name == ColumnTypeName.DECIMAL and isinstance(
                         param_value, Decimal
                     ):
-                        _logger.warning(
-                            f"Param {param_info.name} has decimal value {param_value}, it is converted to float "
-                            "for execution, please note that this conversion may lose precision."
-                        )
                         param_value = float(param_value)
-                    arg_clause += str(param_value)
+                    arg_clause += f"'{str(param_value)}'"
                 args.append(arg_clause)
         sql_query += ",".join(args)
     sql_query += ")"

--- a/src/unitycatalog/ai/databricks.py
+++ b/src/unitycatalog/ai/databricks.py
@@ -489,9 +489,9 @@ class DatabricksFunctionClient(BaseFunctionClient):
 
         else:
             _logger.info("Using databricks connect to execute functions with serverless compute.")
+            self.set_default_spark_session()
+            sql_command = get_execute_function_sql_command(function_info, parameters)
             try:
-                self.set_default_spark_session()
-                sql_command = get_execute_function_sql_command(function_info, parameters)
                 result = self.spark.sql(sqlQuery=sql_command)
                 if is_scalar(function_info):
                     return FunctionExecutionResult(
@@ -504,9 +504,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
                             DEFAULT_UC_AI_CLIENT_EXECUTION_RESULT_ROW_LIMIT,
                         )
                     )
-                    truncated = False
-                    if result.count() > row_limit:
-                        truncated = True
+                    truncated = result.count() > row_limit
                     pdf = result.limit(row_limit).toPandas()
                     csv_buffer = StringIO()
                     pdf.to_csv(csv_buffer, index=False)


### PR DESCRIPTION
Support execution using serverless compute in databricks UC.

Test validated locally:
<img width="978" alt="image" src="https://github.com/user-attachments/assets/17e01bd6-c3e1-4b7a-89ee-83c58f71fc7b">

Currently only row_limit is supported, as limiting byte_size on the spark dataframe result is non-trivial, we can add support later if there're certain requests.
The sql_command generation function is similar to `get_execute_function_sql_stmt` function, but it produces a single sql string so I didn't unify them, otherwise it might get quite messy.

Limitation:
Ideally we should support passing parameters into `spark.sql(sqlQuery=..., args=..., kwargs=...)` to avoid code injection, but with my test it currently doesn't work:
<img width="819" alt="image" src="https://github.com/user-attachments/assets/2fb3687e-cbeb-4cbd-9379-695fdd95e0e6">

<img width="841" alt="image" src="https://github.com/user-attachments/assets/21c71cf4-8cd7-4be2-a3c1-161aa4c9f801">
