### PR TITLE
Drop cluster_id and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,23 @@ To use Databricks-managed Unity Catalog with this package, follow the [instructi
 
 #### Prerequisites
 
+- **[Highly recommended]** Use python>=3.10 for accessing all functionalities including function creation and function execution.
 - Install databricks-sdk package with `pip install databricks-sdk`.
-- For accessing the UC functions in Databricks, please create a SQL warehouse following [this instruction](https://docs.databricks.com/en/compute/sql-warehouse/create.html), and save the warehouse id.
-- [Optional] Install databricks-connect package with `pip install databricks-connect`.
-  - This package is only required for creating UC functions using sql body.
-  - If you want to use [serverless compute](https://docs.databricks.com/en/compute/use-compute.html#use-serverless-compute) for function creation, please make sure you have python>=3.10 and databricks-connect==15.1.0.
-  - If you want to use [your own cluster](https://docs.databricks.com/en/compute/use-compute.html#create-new-compute-using-a-policy) for function creation, please make sure the cluster is up running and pass the cluster_id when creating DatabricksFunctionClient.
+- For creating UC functions with SQL body, **only [serverless compute](https://docs.databricks.com/en/compute/use-compute.html#use-serverless-compute) is supported**.
+  Install databricks-connect package with `pip install databricks-connect==15.1.0`, **python>=3.10** is a requirement to install this version.
+- For executing the UC functions in Databricks, use either SQL warehouse or Databricks Connect with serverless:
+  - SQL warehouse: create a SQL warehouse following [this instruction](https://docs.databricks.com/en/compute/sql-warehouse/create.html), and use the warehouse id when initializing the client.
+    NOTE: **only `serverless` [SQL warehouse type](https://docs.databricks.com/en/admin/sql/warehouse-types.html#sql-warehouse-types) is supported** because of performance concerns.
+  - Databricks connect with serverless: Install databricks-connect package with `pip install databricks-connect==15.1.0`. No config needs to be passed when initializing the client.
 
 #### Client initialization
+
+In this example, we use serverless compute as an example.
 
 ```python
 from ucai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="..." # replace with the warehouse_id
-    cluster_id="..." # optional, only pass when you want to use cluster for function creation
-)
+client = DatabricksFunctionClient()
 ```
 
 #### Create a UC function

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -28,7 +28,6 @@ from ucai.core.databricks import DatabricksFunctionClient
 
 client = DatabricksFunctionClient(
     warehouse_id="..." # replace with the warehouse_id
-    cluster_id="..." # optional, only pass when you want to use cluster for function creation
 )
 
 # sets the default uc function client

--- a/integrations/langchain/tests/test_toolkit.py
+++ b/integrations/langchain/tests/test_toolkit.py
@@ -37,7 +37,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
             tools = toolkit.tools
             assert len(tools) == 1
             tool = tools[0]
-            assert tool.name == func_obj.full_function_name.replace(".", "__")
+            assert tool.name == func_obj.tool_name
             assert tool.description == func_obj.comment
             assert tool.client_config == client.to_dict()
             tool.args_schema(**{"code": "print(1)"})
@@ -46,7 +46,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
 
             toolkit = UCFunctionToolkit(function_names=[f"{CATALOG}.{SCHEMA}.*"])
             assert len(toolkit.tools) >= 1
-            assert get_tool_name(func_obj.full_function_name) in [t.name for t in toolkit.tools]
+            assert func_obj.tool_name in [t.name for t in toolkit.tools]
 
 
 @requires_databricks
@@ -59,7 +59,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
         tools = toolkit.tools
         assert len(tools) == 1
         tool = tools[0]
-        assert tool.name == func_obj.full_function_name.replace(".", "__")
+        assert tool.name == func_obj.tool_name
         assert tool.description == func_obj.comment
         assert tool.client_config == client.to_dict()
         tool.args_schema(**{"code": "print(1)"})
@@ -68,7 +68,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
 
         toolkit = UCFunctionToolkit(function_names=[f"{CATALOG}.{SCHEMA}.*"], client=client)
         assert len(toolkit.tools) >= 1
-        assert get_tool_name(func_obj.full_function_name) in [t.name for t in toolkit.tools]
+        assert func_obj.tool_name in [t.name for t in toolkit.tools]
 
 
 @requires_databricks
@@ -81,7 +81,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
         tools = toolkit.tools
         assert len(tools) == 1
         tool = tools[0]
-        assert tool.name == func_obj.full_function_name.replace(".", "__")
+        assert tool.name == func_obj.tool_name
         assert tool.description == func_obj.comment
         assert tool.client_config == client.to_dict()
         tool.args_schema(**{"code": "print(1)"})
@@ -90,7 +90,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
 
         toolkit = UCFunctionToolkit(function_names=[f"{CATALOG}.{SCHEMA}.*"], client=client)
         assert len(toolkit.tools) >= 1
-        assert get_tool_name(func_obj.full_function_name) in [t.name for t in toolkit.tools]
+        assert func_obj.tool_name in [t.name for t in toolkit.tools]
 
 
 @requires_databricks
@@ -102,9 +102,7 @@ def test_multiple_toolkits(use_serverless, monkeypatch):
         toolkit1 = UCFunctionToolkit(function_names=[func_obj.full_function_name])
         toolkit2 = UCFunctionToolkit(function_names=[f"{CATALOG}.{SCHEMA}.*"])
         tool1 = toolkit1.tools[0]
-        tool2 = [t for t in toolkit2.tools if t.name == get_tool_name(func_obj.full_function_name)][
-            0
-        ]
+        tool2 = [t for t in toolkit2.tools if t.name == func_obj.tool_name][0]
         input_args = {"code": "print(1)"}
         assert tool1.func(**input_args) == tool2.func(**input_args)
 

--- a/integrations/llama_index/README.md
+++ b/integrations/llama_index/README.md
@@ -35,7 +35,6 @@ from ucai.core.databricks import DatabricksFunctionClient
 
 client = DatabricksFunctionClient(
     warehouse_id="..." # replace with the warehouse_id
-    cluster_id="..." # optional, only pass when you want to use cluster for function creation
 )
 
 # sets the default uc function client

--- a/integrations/llama_index/tests/test_toolkit.py
+++ b/integrations/llama_index/tests/test_toolkit.py
@@ -38,7 +38,7 @@ def get_client() -> DatabricksFunctionClient:
         if os.environ.get(USE_SERVERLESS, "false").lower() == "true":
             return DatabricksFunctionClient()
         else:
-            return DatabricksFunctionClient(warehouse_id="warehouse_id", cluster_id="cluster_id")
+            return DatabricksFunctionClient(warehouse_id="warehouse_id")
 
 
 class FunctionObj(NamedTuple):
@@ -79,7 +79,7 @@ def client():
         "ucai.core.databricks.get_default_databricks_workspace_client",
         return_value=mock.Mock(),
     ):
-        yield DatabricksFunctionClient(warehouse_id="warehouse_id", cluster_id="cluster_id")
+        yield DatabricksFunctionClient(warehouse_id="warehouse_id")
 
 
 @contextmanager

--- a/integrations/llama_index/tests/test_toolkit.py
+++ b/integrations/llama_index/tests/test_toolkit.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 from ucai.core.client import (
     FunctionExecutionResult,
 )
-from ucai.core.utils.function_processing_utils import get_tool_name
 from ucai.test_utils.client_utils import (
     USE_SERVERLESS,
     client,  # noqa: F401
@@ -40,7 +39,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
         tools = toolkit.tools
         assert len(tools) == 1
         tool = tools[0]
-        assert tool.metadata.name == get_tool_name(func_obj.full_function_name)
+        assert tool.metadata.name == func_obj.tool_name
         assert tool.metadata.return_direct
         assert tool.metadata.description == func_obj.comment
         assert tool.client_config == client.to_dict()
@@ -51,9 +50,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
 
         toolkit = UCFunctionToolkit(function_names=[f"{CATALOG}.{SCHEMA}.*"])
         assert len(toolkit.tools) >= 1
-        assert get_tool_name(func_obj.full_function_name) in [
-            t.metadata.name for t in toolkit.tools
-        ]
+        assert func_obj.tool_name in [t.metadata.name for t in toolkit.tools]
 
 
 @requires_databricks
@@ -68,7 +65,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
         tools = toolkit.tools
         assert len(tools) == 1
         tool = tools[0]
-        assert tool.metadata.name == get_tool_name(func_obj.full_function_name)
+        assert tool.metadata.name == func_obj.tool_name
         assert tool.metadata.return_direct
         assert tool.metadata.description == func_obj.comment
         assert tool.client_config == client.to_dict()
@@ -78,9 +75,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
 
         toolkit = UCFunctionToolkit(function_names=[f"{CATALOG}.{SCHEMA}.*"], client=client)
         assert len(toolkit.tools) >= 1
-        assert get_tool_name(func_obj.full_function_name) in [
-            t.metadata.name for t in toolkit.tools
-        ]
+        assert func_obj.tool_name in [t.metadata.name for t in toolkit.tools]
 
 
 @requires_databricks
@@ -92,11 +87,7 @@ def test_multiple_toolkits(use_serverless, monkeypatch):
         toolkit1 = UCFunctionToolkit(function_names=[func_obj.full_function_name])
         toolkit2 = UCFunctionToolkit(function_names=[f"{CATALOG}.{SCHEMA}.*"])
         tool1 = toolkit1.tools[0]
-        tool2 = [
-            t
-            for t in toolkit2.tools
-            if t.metadata.name == get_tool_name(func_obj.full_function_name)
-        ][0]
+        tool2 = [t for t in toolkit2.tools if t.metadata.name == func_obj.tool_name][0]
         input_args = {"code": "print(1)"}
         result1 = json.loads(tool1.fn(**input_args))["value"]
         result2 = json.loads(tool2.fn(**input_args))["value"]

--- a/integrations/openai/README.md
+++ b/integrations/openai/README.md
@@ -28,7 +28,6 @@ from ucai.core.databricks import DatabricksFunctionClient
 
 client = DatabricksFunctionClient(
     warehouse_id="..." # replace with the warehouse_id
-    cluster_id="..." # optional, only pass when you want to use cluster for function creation
 )
 
 # sets the default uc function client

--- a/integrations/openai/tests/test_toolkit.py
+++ b/integrations/openai/tests/test_toolkit.py
@@ -34,7 +34,7 @@ def test_tool_calling(use_serverless, monkeypatch):
     client = get_client()
     with (
         set_default_client(client),
-        create_function_and_cleanup(client, return_func_name=True) as func_obj,
+        create_function_and_cleanup(client) as func_obj,
     ):
         func_name = func_obj.full_function_name
         toolkit = UCFunctionToolkit(function_names=[func_name])
@@ -99,7 +99,7 @@ def test_tool_calling_with_multiple_choices(use_serverless, monkeypatch):
     client = get_client()
     with (
         set_default_client(client),
-        create_function_and_cleanup(client, return_func_name=True) as func_obj,
+        create_function_and_cleanup(client) as func_obj,
     ):
         func_name = func_obj.full_function_name
         toolkit = UCFunctionToolkit(function_names=[func_name])

--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -138,6 +138,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
         """
         self.client = client or get_default_databricks_workspace_client()
         self.warehouse_id = warehouse_id
+        self._validate_warehouse_type()
         self.profile = profile
         # TODO: add CI to run this in Databricks notebook
         self.spark = _try_get_spark_session_in_dbr()
@@ -157,6 +158,17 @@ class DatabricksFunctionClient(BaseFunctionClient):
     def stop_spark_session(self):
         if self.spark is not None and not self.spark.is_stopped:
             self.spark.stop()
+
+    def _validate_warehouse_type(self):
+        if (
+            self.warehouse_id
+            and not self.client.warehouses.get(self.warehouse_id).enable_serverless_compute
+        ):
+            raise ValueError(
+                f"Warehouse {self.warehouse_id} does not support serverless compute. "
+                "Please use a serverless warehouse following the instructions here: "
+                "https://docs.databricks.com/en/admin/sql/serverless.html#enable-serverless-sql-warehouses."
+            )
 
     @override
     def create_function(

--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -421,7 +421,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
                 retry_cnt += 1
             if response.status and job_pending(response.status.state):
                 return FunctionExecutionResult(
-                    error=f"Statement execution is still pending after {wait_time} "
+                    error=f"Statement execution is still {response.status.state.value.lower()} after {wait_time} "
                     "seconds. Please increase the wait_timeout argument for executing "
                     f"the function or increase {UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT} environment "
                     f"variable for increasing retrying time, default value is {DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT} seconds."

--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -41,6 +41,15 @@ DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT = "120"
 UC_AI_CLIENT_EXECUTION_RESULT_ROW_LIMIT = "UC_AI_CLIENT_EXECUTION_RESULT_ROW_LIMIT"
 DEFAULT_UC_AI_CLIENT_EXECUTION_RESULT_ROW_LIMIT = "100"
 
+DATABRICKS_CONNECT_SUPPORTED_VERSION = "15.1.0"
+DATABRICKS_CONNECT_IMPORT_ERROR_MESSAGE = "Could not import databricks-connect python package. "
+"TO interact with UC functions using serverless compute, install the package with "
+f"`pip install databricks-connect=={DATABRICKS_CONNECT_SUPPORTED_VERSION}`. "
+"Please note this requires python>=3.10."
+DATABRICKS_CONNECT_VERSION_NOT_SUPPORTED_ERROR_MESSAGE = "Serverless is not supported by the "
+"current databricks-connect version, install with "
+f"`pip install databricks-connect=={DATABRICKS_CONNECT_SUPPORTED_VERSION}` "
+"to use serverless compute in Databricks. Please note this requires python>=3.10."
 
 _logger = logging.getLogger(__name__)
 
@@ -57,13 +66,14 @@ def get_default_databricks_workspace_client() -> "WorkspaceClient":
     return WorkspaceClient()
 
 
-def _databricks_connect_available() -> bool:
+def _validate_databricks_connect_available() -> bool:
     try:
         from databricks.connect.session import DatabricksSession  # noqa: F401
 
-        return True
-    except ImportError:
-        return False
+        if not hasattr(DatabricksSession.builder, "serverless"):
+            raise Exception(DATABRICKS_CONNECT_VERSION_NOT_SUPPORTED_ERROR_MESSAGE)
+    except ImportError as e:
+        raise Exception(DATABRICKS_CONNECT_IMPORT_ERROR_MESSAGE) from e
 
 
 def _try_get_spark_session_in_dbr() -> Any:
@@ -113,7 +123,6 @@ class DatabricksFunctionClient(BaseFunctionClient):
         client: Optional["WorkspaceClient"] = None,
         *,
         warehouse_id: Optional[str] = None,
-        cluster_id: Optional[str] = None,
         profile: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
@@ -125,14 +134,10 @@ class DatabricksFunctionClient(BaseFunctionClient):
                 is generated based on the configuration. Defaults to None.
             warehouse_id: The warehouse id to use for executing functions. This field is
                 not needed if serverless is enabled in the databricks workspace. Defaults to None.
-            cluster_id: The cluster id to use for creating functions. Make sure the cluster
-                is up and running before creating the function. This field is not needed if databricks-connect
-                is installed and serverless is enabled in databricks workspace. Defaults to None.
             profile: The configuration profile to use for databricks connect. Defaults to None.
         """
         self.client = client or get_default_databricks_workspace_client()
         self.warehouse_id = warehouse_id
-        self.cluster_id = cluster_id
         self.profile = profile
         # TODO: add CI to run this in Databricks notebook
         self.spark = _try_get_spark_session_in_dbr()
@@ -140,37 +145,14 @@ class DatabricksFunctionClient(BaseFunctionClient):
 
     def set_default_spark_session(self):
         if self.spark is None or self.spark.is_stopped:
-            try:
-                from databricks.connect.session import DatabricksSession as SparkSession
+            _validate_databricks_connect_available()
+            from databricks.connect.session import DatabricksSession as SparkSession
 
-                if self.profile:
-                    builder = SparkSession.builder.profile(self.profile)
-                else:
-                    builder = SparkSession.builder
-
-                if hasattr(SparkSession.Builder, "serverless"):
-                    self.spark = builder.serverless(True).getOrCreate()
-                else:
-                    _logger.warning(
-                        "Serverless is not supported by the current databricks-connect "
-                        "version, please install with `pip install databricks-connect==15.1.0` "
-                        "to use serverless compute in Databricks."
-                    )
-                    # serverless is not supported in older versions of databricks-connect
-                    # a cluster id must be provided instead
-                    if self.cluster_id:
-                        self.spark = builder.remote(cluster_id=self.cluster_id).getOrCreate()
-                    else:
-                        raise ValueError(
-                            "cluster_id is required for connecting to a spark session in Databricks. "
-                            "Please provide it when constructing the DatabricksFunctionClient."
-                        )
-            except ImportError as e:
-                raise ImportError(
-                    "Could not import databricks-connect python package. "
-                    "If you want to use databricks with dbconnect to create UC functions "
-                    "then please install it with `pip install databricks-connect`."
-                ) from e
+            if self.profile:
+                builder = SparkSession.builder.profile(self.profile)
+            else:
+                builder = SparkSession.builder
+            self.spark = builder.serverless(True).getOrCreate()
 
     def stop_spark_session(self):
         if self.spark is not None and not self.spark.is_stopped:
@@ -186,14 +168,14 @@ class DatabricksFunctionClient(BaseFunctionClient):
         """
         Create a UC function with the given sql body or function info.
 
+        Note: `databricks-connect` is required to use this function, make sure its version is 15.1.0 or above to use
+            serverless compute.
+
         Args:
             sql_function_body: The sql body of the function. Defaults to None.
                 It should follow the syntax of CREATE FUNCTION statement in Databricks.
                 Ref: https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-sql-function.html#syntax
 
-                .. Note:: This is supported using databricks connect; if databricks-connect version is 15.1.0 or above,
-                    by default it uses serverless compute; otherwise please provide a cluster_id when constructing the client
-                    and the client will use remote cluster to create the function.
             function_info: The function info. Defaults to None.
 
         Returns:
@@ -202,50 +184,14 @@ class DatabricksFunctionClient(BaseFunctionClient):
         if sql_function_body and function_info:
             raise ValueError("Only one of sql_function_body and function_info should be provided.")
         if sql_function_body:
-            # databricks-connect is easier to use for executing command than databricks-sdk,
-            # so we use databricks-connect to create function if available
-            if _databricks_connect_available():
-                _logger.info("Using databricks connect to create function.")
-                try:
-                    self.set_default_spark_session()
-                    self.spark.sql(sql_function_body)
-                except Exception as e:
-                    raise RuntimeError(
-                        f"Failed to create function with sql body: {sql_function_body}"
-                    ) from e
-            elif self.cluster_id:
-                _logger.info("Using databricks cluster to create function.")
-                from databricks.sdk.service.compute import CommandStatus, ContextStatus, Language
-
-                context_result = self.client._command_execution.create_and_wait(
-                    cluster_id=self.cluster_id, language=Language.SQL
-                )
-                if context_result.status == ContextStatus.RUNNING:
-                    result = self.client._command_execution.execute_and_wait(
-                        cluster_id=self.cluster_id,
-                        command=sql_function_body,
-                        context_id=context_result.id,
-                        language=Language.SQL,
-                    )
-                    if result.status in (
-                        CommandStatus.ERROR,
-                        CommandStatus.CANCELLED,
-                        CommandStatus.CANCELLING,
-                    ):
-                        raise Exception(f"Error when executing the command: {result}")
-                # TODO: add retry here
-                elif context_result.status == ContextStatus.PENDING:
-                    raise Exception(
-                        "The cluster is still pending, please wait for it to be running and try again later"
-                    )
-                else:
-                    raise Exception(
-                        "Error when starting the cluster, please check the cluster status and try again later"
-                    )
-            else:
-                raise Exception(
-                    "Cannot create function with sql body without databricks connect or cluster_id."
-                )
+            self.set_default_spark_session()
+            try:
+                # TODO: add timeout
+                self.spark.sql(sql_function_body)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to create function with sql body: {sql_function_body}"
+                ) from e
             return self.get_function(extract_function_name(sql_function_body))
         if function_info:
             # TODO: support this after CreateFunction bug is fixed in databricks-sdk
@@ -382,10 +328,22 @@ class DatabricksFunctionClient(BaseFunctionClient):
     def _execute_uc_function(
         self, function_info: "FunctionInfo", parameters: Dict[str, Any], **kwargs: Any
     ) -> Any:
+        if self.warehouse_id:
+            return self._execute_uc_functions_with_warehouse(function_info, parameters)
+        else:
+            return self._execute_uc_functions_with_serverless(function_info, parameters)
+
+    def _execute_uc_functions_with_warehouse(
+        self, function_info: "FunctionInfo", parameters: Dict[str, Any]
+    ) -> FunctionExecutionResult:
         from databricks.sdk.service.sql import StatementState
 
+        _logger.info("Executing function using client warehouse_id.")
+
+        passed_execute_statement_args = parameters.pop(EXECUTE_FUNCTION_ARG_NAME, {})
         if (
-            function_info.input_params
+            passed_execute_statement_args
+            and function_info.input_params
             and function_info.input_params.parameters
             and any(
                 p.name == EXECUTE_FUNCTION_ARG_NAME for p in function_info.input_params.parameters
@@ -407,7 +365,6 @@ class DatabricksFunctionClient(BaseFunctionClient):
             for p in allowed_execute_statement_args.values()
         ):
             invalid_params: Set[str] = set()
-            passed_execute_statement_args = parameters.pop(EXECUTE_FUNCTION_ARG_NAME, {})
             for k, v in passed_execute_statement_args.items():
                 if k in allowed_execute_statement_args:
                     execute_statement_args[k] = v
@@ -419,124 +376,122 @@ class DatabricksFunctionClient(BaseFunctionClient):
                     f"Allowed parameters are: {allowed_execute_statement_args.keys()}."
                 )
 
-        if self.warehouse_id:
-            _logger.info("Executing function using client warehouse_id.")
-            parametrized_statement = get_execute_function_sql_stmt(function_info, parameters)
-            response = self.client.statement_execution.execute_statement(
-                statement=parametrized_statement.statement,
-                warehouse_id=self.warehouse_id,
-                parameters=parametrized_statement.parameters,
-                **execute_statement_args,  # type: ignore
+        parametrized_statement = get_execute_function_sql_stmt(function_info, parameters)
+        response = self.client.statement_execution.execute_statement(
+            statement=parametrized_statement.statement,
+            warehouse_id=self.warehouse_id,
+            parameters=parametrized_statement.parameters,
+            **execute_statement_args,  # type: ignore
+        )
+        # TODO: the first time the warehouse is invoked, it might take longer than
+        # expected, so it's still pending even after 6 times of retry;
+        # we should see if we can check the warehouse status before invocation, and
+        # increase the wait time if needed
+        if response.status and job_pending(response.status.state) and response.statement_id:
+            statement_id = response.statement_id
+            _logger.info("Retrying to get statement execution status...")
+            wait_time = 0
+            retry_cnt = 0
+            client_execution_timeout = int(
+                os.environ.get(
+                    UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT,
+                    DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT,
+                )
             )
-            # TODO: the first time the warehouse is invoked, it might take longer than
-            # expected, so it's still pending even after 6 times of retry;
-            # we should see if we can check the warehouse status before invocation, and
-            # increase the wait time if needed
-            if response.status and job_pending(response.status.state) and response.statement_id:
-                statement_id = response.statement_id
-                _logger.info("Retrying to get statement execution status...")
-                wait_time = 0
-                retry_cnt = 0
-                client_execution_timeout = int(
-                    os.environ.get(
-                        UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT,
-                        DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT,
-                    )
+            while wait_time < client_execution_timeout:
+                wait = min(2**retry_cnt, client_execution_timeout - wait_time)
+                time.sleep(wait)
+                _logger.info(f"Retry times: {retry_cnt}")
+                response = self.client.statement_execution.get_statement(statement_id)
+                if response.status is None or not job_pending(response.status.state):
+                    break
+                wait_time += wait
+                retry_cnt += 1
+            if response.status and job_pending(response.status.state):
+                return FunctionExecutionResult(
+                    error=f"Statement execution is still pending after {wait_time} "
+                    "seconds. Please increase the wait_timeout argument for executing "
+                    f"the function or increase {UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT} environment "
+                    f"variable for increasing retrying time, default value is {DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT} seconds."
                 )
-                while wait_time < client_execution_timeout:
-                    wait = min(2**retry_cnt, client_execution_timeout - wait_time)
-                    time.sleep(wait)
-                    _logger.info(f"Retry times: {retry_cnt}")
-                    response = self.client.statement_execution.get_statement(statement_id)
-                    if response.status is None or not job_pending(response.status.state):
-                        break
-                    wait_time += wait
-                    retry_cnt += 1
-                if response.status and job_pending(response.status.state):
-                    return FunctionExecutionResult(
-                        error=f"Statement execution is still pending after {wait_time} "
-                        "seconds. Please increase the wait_timeout argument for executing "
-                        f"the function or increase {UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT} environment "
-                        f"variable for increasing retrying time, default value is {DEFAULT_UC_AI_CLIENT_EXECUTION_TIMEOUT} seconds."
-                    )
-            if response.status is None:
-                return FunctionExecutionResult(error=f"Statement execution failed: {response}")
-            if response.status.state != StatementState.SUCCEEDED:
-                error = response.status.error
-                if error is None:
-                    return FunctionExecutionResult(
-                        error=f"Statement execution failed but no error message was provided: {response}"
-                    )
-                return FunctionExecutionResult(error=f"{error.error_code}: {error.message}")
+        if response.status is None:
+            return FunctionExecutionResult(error=f"Statement execution failed: {response}")
+        if response.status.state != StatementState.SUCCEEDED:
+            error = response.status.error
+            if error is None:
+                return FunctionExecutionResult(
+                    error=f"Statement execution failed but no error message was provided: {response}"
+                )
+            return FunctionExecutionResult(error=f"{error.error_code}: {error.message}")
 
-            manifest = response.manifest
-            if manifest is None:
+        manifest = response.manifest
+        if manifest is None:
+            return FunctionExecutionResult(
+                error="Statement execution succeeded but no manifest was returned."
+            )
+        truncated = manifest.truncated
+        if response.result is None:
+            return FunctionExecutionResult(
+                error="Statement execution succeeded but no result was provided."
+            )
+        data_array = response.result.data_array
+        if is_scalar(function_info):
+            value = None
+            if data_array and len(data_array) > 0 and len(data_array[0]) > 0:
+                # value is always string type
+                value = data_array[0][0]
+            return FunctionExecutionResult(format="SCALAR", value=value, truncated=truncated)
+        else:
+            try:
+                import pandas as pd
+            except ImportError as e:
+                raise ImportError(
+                    "Could not import pandas python package. Please install it with `pip install pandas`."
+                ) from e
+
+            schema = manifest.schema
+            if schema is None or schema.columns is None:
                 return FunctionExecutionResult(
-                    error="Statement execution succeeded but no manifest was returned."
+                    error="Statement execution succeeded but no schema was provided for table function."
                 )
-            truncated = manifest.truncated
-            if response.result is None:
-                return FunctionExecutionResult(
-                    error="Statement execution succeeded but no result was provided."
-                )
-            data_array = response.result.data_array
+            columns = [c.name for c in schema.columns]
+            if data_array is None:
+                data_array = []
+            pdf = pd.DataFrame(data_array, columns=columns)
+            csv_buffer = StringIO()
+            pdf.to_csv(csv_buffer, index=False)
+            return FunctionExecutionResult(
+                format="CSV", value=csv_buffer.getvalue(), truncated=truncated
+            )
+
+    def _execute_uc_functions_with_serverless(
+        self, function_info: "FunctionInfo", parameters: Dict[str, Any]
+    ) -> FunctionExecutionResult:
+        _logger.info("Using databricks connect to execute functions with serverless compute.")
+        self.set_default_spark_session()
+        sql_command = get_execute_function_sql_command(function_info, parameters)
+        try:
+            result = self.spark.sql(sqlQuery=sql_command)
             if is_scalar(function_info):
-                value = None
-                if data_array and len(data_array) > 0 and len(data_array[0]) > 0:
-                    # value is always string type
-                    value = data_array[0][0]
-                return FunctionExecutionResult(format="SCALAR", value=value, truncated=truncated)
+                return FunctionExecutionResult(format="SCALAR", value=str(result.collect()[0][0]))
             else:
-                try:
-                    import pandas as pd
-                except ImportError as e:
-                    raise ImportError(
-                        "Could not import pandas python package. Please install it with `pip install pandas`."
-                    ) from e
-
-                schema = manifest.schema
-                if schema is None or schema.columns is None:
-                    return FunctionExecutionResult(
-                        error="Statement execution succeeded but no schema was provided for table function."
+                row_limit = int(
+                    os.environ.get(
+                        UC_AI_CLIENT_EXECUTION_RESULT_ROW_LIMIT,
+                        DEFAULT_UC_AI_CLIENT_EXECUTION_RESULT_ROW_LIMIT,
                     )
-                columns = [c.name for c in schema.columns]
-                if data_array is None:
-                    data_array = []
-                pdf = pd.DataFrame(data_array, columns=columns)
+                )
+                truncated = result.count() > row_limit
+                pdf = result.limit(row_limit).toPandas()
                 csv_buffer = StringIO()
                 pdf.to_csv(csv_buffer, index=False)
                 return FunctionExecutionResult(
                     format="CSV", value=csv_buffer.getvalue(), truncated=truncated
                 )
-
-        else:
-            _logger.info("Using databricks connect to execute functions with serverless compute.")
-            self.set_default_spark_session()
-            sql_command = get_execute_function_sql_command(function_info, parameters)
-            try:
-                result = self.spark.sql(sqlQuery=sql_command)
-                if is_scalar(function_info):
-                    return FunctionExecutionResult(
-                        format="SCALAR", value=str(result.collect()[0][0])
-                    )
-                else:
-                    row_limit = int(
-                        os.environ.get(
-                            UC_AI_CLIENT_EXECUTION_RESULT_ROW_LIMIT,
-                            DEFAULT_UC_AI_CLIENT_EXECUTION_RESULT_ROW_LIMIT,
-                        )
-                    )
-                    truncated = result.count() > row_limit
-                    pdf = result.limit(row_limit).toPandas()
-                    csv_buffer = StringIO()
-                    pdf.to_csv(csv_buffer, index=False)
-                    return FunctionExecutionResult(
-                        format="CSV", value=csv_buffer.getvalue(), truncated=truncated
-                    )
-            except Exception as e:
-                raise RuntimeError(
-                    f"Failed to execute function with function name: {function_info.full_name}"
-                ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to execute function with function name: {function_info.full_name}"
+            ) from e
 
     @override
     def validate_input_params(self, input_params: Any, parameters: Dict[str, Any]) -> None:
@@ -549,13 +504,12 @@ class DatabricksFunctionClient(BaseFunctionClient):
         return {
             # TODO: workspaceClient related config
             "warehouse_id": self.warehouse_id,
-            "cluster_id": self.cluster_id,
             "profile": self.profile,
         }
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]):
-        accept_keys = ["warehouse_id", "cluster_id", "profile"]
+        accept_keys = ["warehouse_id", "profile"]
         return cls(**{k: v for k, v in config.items() if k in accept_keys})
 
 

--- a/src/ucai/test_utils/client_utils.py
+++ b/src/ucai/test_utils/client_utils.py
@@ -17,16 +17,14 @@ def requires_databricks(test_func):
     )(test_func)
 
 
-# TODO: CI -- two test cases
-# 1. python 3.10 with databricks-connect 15.1.0, no cluster_id, use serverless
-# 2. python 3.9 with databricks-sdk, with cluster_id
+# TODO: CI -- only support python 3.10, test with databricks-connect 15.1.0 + serverless
 @pytest.fixture
 def client() -> DatabricksFunctionClient:
     with mock.patch(
         "ucai.core.databricks.get_default_databricks_workspace_client",
         return_value=mock.Mock(),
     ):
-        return DatabricksFunctionClient(warehouse_id="warehouse_id", cluster_id="cluster_id")
+        return DatabricksFunctionClient(warehouse_id="warehouse_id")
 
 
 @pytest.fixture
@@ -42,7 +40,7 @@ def get_client() -> DatabricksFunctionClient:
         if os.environ.get(USE_SERVERLESS, "false").lower() == "true":
             return DatabricksFunctionClient()
         else:
-            return DatabricksFunctionClient(warehouse_id="warehouse_id", cluster_id="cluster_id")
+            return DatabricksFunctionClient(warehouse_id="warehouse_id")
 
 
 @contextmanager

--- a/src/ucai/test_utils/client_utils.py
+++ b/src/ucai/test_utils/client_utils.py
@@ -8,6 +8,7 @@ from ucai.core.client import set_uc_function_client
 from ucai.core.databricks import DatabricksFunctionClient
 
 USE_SERVERLESS = "USE_SERVERLESS"
+WAREHOUSE_ID = "warehouse_id"
 
 
 def requires_databricks(test_func):
@@ -24,7 +25,7 @@ def client() -> DatabricksFunctionClient:
         "ucai.core.databricks.get_default_databricks_workspace_client",
         return_value=mock.Mock(),
     ):
-        return DatabricksFunctionClient(warehouse_id="warehouse_id")
+        return DatabricksFunctionClient(warehouse_id=WAREHOUSE_ID)
 
 
 @pytest.fixture
@@ -40,7 +41,7 @@ def get_client() -> DatabricksFunctionClient:
         if os.environ.get(USE_SERVERLESS, "false").lower() == "true":
             return DatabricksFunctionClient()
         else:
-            return DatabricksFunctionClient(warehouse_id="warehouse_id")
+            return DatabricksFunctionClient(warehouse_id=WAREHOUSE_ID)
 
 
 @contextmanager

--- a/src/ucai/test_utils/function_utils.py
+++ b/src/ucai/test_utils/function_utils.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from typing import Generator, NamedTuple, Optional
 
 from ucai.core.databricks import DatabricksFunctionClient
+from ucai.core.utils.function_processing_utils import get_tool_name
 
 CATALOG = "ml"
 SCHEMA = "serena_uc_test"
@@ -33,6 +34,7 @@ def generate_func_name_and_cleanup(client: DatabricksFunctionClient):
 class FunctionObj(NamedTuple):
     full_function_name: str
     comment: str
+    tool_name: str
 
 
 @contextmanager
@@ -62,7 +64,9 @@ $$
     )
     try:
         client.create_function(sql_function_body=sql_body)
-        yield FunctionObj(full_function_name=func_name, comment=comment)
+        yield FunctionObj(
+            full_function_name=func_name, comment=comment, tool_name=get_tool_name(func_name)
+        )
     finally:
         try:
             client.client.functions.delete(func_name)

--- a/tests/core/test_databricks_client.py
+++ b/tests/core/test_databricks_client.py
@@ -304,7 +304,7 @@ $$
 """
         client.create_function(sql_function_body=sql_body)
         result = client.execute_function(func_name)
-        assert result.error.startswith("Statement execution is still pending after 5 seconds")
+        assert result.error.startswith("Statement execution is still running after 5 seconds")
 
         monkeypatch.setenv(UNITYCATALOG_AI_CLIENT_EXECUTION_TIMEOUT, "100")
         result = client.execute_function(func_name)


### PR DESCRIPTION
After offline discussion, we'd like to drop support of cluster_id when creating function -- it requires the cluster to be ready to run, otherwise the cluster starting process takes a long time and the user experience would be so bad.
Refactor and update:
 - If databricks-connect version doesn't support serverless, directly raise error. Python>=3.10 will be a hard requirement to use databricks client. (DBR >= 13.3 supports python>=3.10, we should be fine)
 - Only serverless warehouse is supported