### PR TITLE
Add NoOp client

### DIFF
--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -14,7 +14,7 @@ from typing_extensions import override
 
 from ucai.core.client import BaseFunctionClient, FunctionExecutionResult
 from ucai.core.paged_list import PagedList
-from ucai.core.utils.databricks_utils import get_default_databricks_workspace_client
+from ucai.core.utils.databricks_utils import NoOpClient, get_default_databricks_workspace_client
 from ucai.core.utils.type_utils import (
     column_type_to_python_type,
     convert_timedelta_to_interval_str,
@@ -496,6 +496,8 @@ class DatabricksFunctionClient(BaseFunctionClient):
 
     @override
     def validate_input_params(self, input_params: Any, parameters: Dict[str, Any]) -> None:
+        if isinstance(self.client, NoOpClient):
+            return
         super().validate_input_params(
             input_params, {k: v for k, v in parameters.items() if k != EXECUTE_FUNCTION_ARG_NAME}
         )

--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -14,6 +14,7 @@ from typing_extensions import override
 
 from ucai.core.client import BaseFunctionClient, FunctionExecutionResult
 from ucai.core.paged_list import PagedList
+from ucai.core.utils.databricks_utils import get_default_databricks_workspace_client
 from ucai.core.utils.type_utils import (
     column_type_to_python_type,
     convert_timedelta_to_interval_str,
@@ -52,18 +53,6 @@ f"`pip install databricks-connect=={DATABRICKS_CONNECT_SUPPORTED_VERSION}` "
 "to use serverless compute in Databricks. Please note this requires python>=3.10."
 
 _logger = logging.getLogger(__name__)
-
-
-def get_default_databricks_workspace_client() -> "WorkspaceClient":
-    try:
-        from databricks.sdk import WorkspaceClient
-    except ImportError as e:
-        raise ImportError(
-            "Could not import databricks-sdk python package. "
-            "If you want to use databricks backend then "
-            "please install it with `pip install databricks-sdk`."
-        ) from e
-    return WorkspaceClient()
 
 
 def _validate_databricks_connect_available() -> bool:

--- a/src/ucai/core/utils/databricks_utils.py
+++ b/src/ucai/core/utils/databricks_utils.py
@@ -1,0 +1,62 @@
+import logging
+from typing import TYPE_CHECKING
+
+_logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from databricks.sdk import WorkspaceClient
+
+
+def get_default_databricks_workspace_client() -> "WorkspaceClient":
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        return WorkspaceClient()
+    except ImportError as e:
+        raise ImportError(
+            "Could not import databricks-sdk python package. "
+            "If you want to use databricks backend then "
+            "please install it with `pip install databricks-sdk`."
+        ) from e
+    except Exception as e:
+        _logger.warning(
+            "Failed to initialize databricks workspace client "
+            f"Falling back to NoOpClient. Error: {e}"
+        )
+    return NoOpClient()
+
+
+class NoOpStatementExecutionAPI:
+    def execute_statement(self, *args, **kwargs):
+        from databricks.sdk.service.sql import (
+            ResultData,
+            ResultManifest,
+            StatementResponse,
+            StatementState,
+            StatementStatus,
+        )
+
+        return StatementResponse(
+            manifest=ResultManifest(truncated=False),
+            result=ResultData(data_array=[["null"]]),
+            status=StatementStatus(state=StatementState.SUCCEEDED),
+        )
+
+
+class NoOpAPIClient:
+    def do(self, *args, **kwargs):
+        return {}
+
+
+class NoOpFunctionsAPI:
+    _api: NoOpAPIClient = NoOpAPIClient()
+
+    def get(self, *args, **kwargs):
+        from databricks.sdk.service.catalog import FunctionInfo
+
+        return FunctionInfo()
+
+
+class NoOpClient:
+    statement_execution: NoOpStatementExecutionAPI = NoOpStatementExecutionAPI()
+    functions: NoOpFunctionsAPI = NoOpFunctionsAPI()

--- a/src/ucai/core/utils/databricks_utils.py
+++ b/src/ucai/core/utils/databricks_utils.py
@@ -38,7 +38,7 @@ class _NoOpStatementExecutionAPI:
 
         return StatementResponse(
             manifest=ResultManifest(truncated=False),
-            result=ResultData(data_array=[["null"]]),
+            result=ResultData(data_array=[[]]),
             status=StatementStatus(state=StatementState.SUCCEEDED),
         )
 

--- a/src/ucai/core/utils/databricks_utils.py
+++ b/src/ucai/core/utils/databricks_utils.py
@@ -57,6 +57,16 @@ class NoOpFunctionsAPI:
         return FunctionInfo()
 
 
+class NoOpWarehouse:
+    enable_serverless_compute: bool = True
+
+
+class NoOpWarehousesAPI:
+    def get(self, *args, **kwargs):
+        return NoOpWarehouse()
+
+
 class NoOpClient:
     statement_execution: NoOpStatementExecutionAPI = NoOpStatementExecutionAPI()
     functions: NoOpFunctionsAPI = NoOpFunctionsAPI()
+    warehouses: NoOpWarehousesAPI = NoOpWarehousesAPI()

--- a/src/ucai/core/utils/databricks_utils.py
+++ b/src/ucai/core/utils/databricks_utils.py
@@ -26,7 +26,7 @@ def get_default_databricks_workspace_client() -> "WorkspaceClient":
     return NoOpClient()
 
 
-class NoOpStatementExecutionAPI:
+class _NoOpStatementExecutionAPI:
     def execute_statement(self, *args, **kwargs):
         from databricks.sdk.service.sql import (
             ResultData,
@@ -43,13 +43,13 @@ class NoOpStatementExecutionAPI:
         )
 
 
-class NoOpAPIClient:
+class _NoOpAPIClient:
     def do(self, *args, **kwargs):
         return {}
 
 
-class NoOpFunctionsAPI:
-    _api: NoOpAPIClient = NoOpAPIClient()
+class _NoOpFunctionsAPI:
+    _api: _NoOpAPIClient = _NoOpAPIClient()
 
     def get(self, *args, **kwargs):
         from databricks.sdk.service.catalog import FunctionInfo
@@ -57,16 +57,19 @@ class NoOpFunctionsAPI:
         return FunctionInfo()
 
 
-class NoOpWarehouse:
+class _NoOpWarehouse:
     enable_serverless_compute: bool = True
 
 
-class NoOpWarehousesAPI:
+class _NoOpWarehousesAPI:
     def get(self, *args, **kwargs):
-        return NoOpWarehouse()
+        return _NoOpWarehouse()
 
 
+# This is a no-op client that can be used as a fallback when the databricks
+# WorkspaceClient fails to initialize. It mocks the behavior of WorkspaceClient
+# and its methods used in the UCAI codebase, but actually does nothing.
 class NoOpClient:
-    statement_execution: NoOpStatementExecutionAPI = NoOpStatementExecutionAPI()
-    functions: NoOpFunctionsAPI = NoOpFunctionsAPI()
-    warehouses: NoOpWarehousesAPI = NoOpWarehousesAPI()
+    statement_execution: _NoOpStatementExecutionAPI = _NoOpStatementExecutionAPI()
+    functions: _NoOpFunctionsAPI = _NoOpFunctionsAPI()
+    warehouses: _NoOpWarehousesAPI = _NoOpWarehousesAPI()

--- a/tests/core/test_databricks_client.py
+++ b/tests/core/test_databricks_client.py
@@ -823,4 +823,4 @@ def test_default_noop_client_if_databricks_sdk_missing():
         assert function_info is not None
         assert all(x is None for x in function_info.__dict__.values())
         assert client.list_functions(catalog="catalog", schema="schema") == []
-        assert client.execute_function("catalog.schema.test").value == "null"
+        assert client.execute_function("catalog.schema.test").value is None

--- a/tests/core/test_databricks_client.py
+++ b/tests/core/test_databricks_client.py
@@ -823,5 +823,4 @@ def test_default_noop_client_if_databricks_sdk_missing():
         assert function_info is not None
         assert all(x is None for x in function_info.__dict__.values())
         assert client.list_functions(catalog="catalog", schema="schema") == []
-        with mock.patch.object(client, "validate_input_params"):
-            assert client.execute_function("catalog.schema.test").value == "null"
+        assert client.execute_function("catalog.schema.test").value == "null"


### PR DESCRIPTION
Add NoOpClient if WorkspaceClient initialization fails.
This is to prevent the client from failing inside subprocess, though it doesn't fixes the case when serverless client is used instead of SQL warehouse.