### PR TITLE
Update LlamaIndex for tool schema validation

### DIFF
--- a/integrations/llama_index/src/ucai_llamaindex/toolkit.py
+++ b/integrations/llama_index/src/ucai_llamaindex/toolkit.py
@@ -1,5 +1,3 @@
-# src/ucai_llamaindex/toolkit.py
-
 from typing import Any, Callable, Dict, List, Optional
 
 from llama_index.core.tools import FunctionTool
@@ -118,7 +116,7 @@ class UCFunctionToolkit(BaseModel):
         fn_schema = generate_function_input_params_schema(function_info)
         pydantic_model = fn_schema.pydantic_model
 
-        # Enforce strict validation by setting 'extra' to 'forbid'
+        # Enforce strict validation by setting 'extra' to 'forbid' for both outer and inner models
         WrappedModel = create_model(
             f"{pydantic_model.__name__}_Wrapper",
             properties=(pydantic_model, Field(...)),
@@ -135,8 +133,8 @@ class UCFunctionToolkit(BaseModel):
             except ValidationError as e:
                 raise ValueError("Extra parameters provided that are not defined") from e
 
-            # Extract all function parameters
-            function_params = validated_input.model_dump()
+            # Extract the 'properties' field containing the actual parameters
+            function_params = validated_input.properties.model_dump()
 
             # Execute the function with the parameters
             result = client.execute_function(

--- a/integrations/llama_index/tests/test_toolkit.py
+++ b/integrations/llama_index/tests/test_toolkit.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from databricks.sdk.service.catalog import (
+    ColumnTypeName,
     FunctionInfo,
     FunctionParameterInfo,
     FunctionParameterInfos,
@@ -118,7 +119,7 @@ def generate_function_info():
             "name": "x",
             "type_text": "string",
             "type_json": '{"name":"x","type":"string","nullable":true,"metadata":{"EXISTS_DEFAULT":"\\"123\\"","default":"\\"123\\"","CURRENT_DEFAULT":"\\"123\\""}}',
-            "type_name": "STRING",
+            "type_name": ColumnTypeName.STRING,
             "type_precision": 0,
             "type_scale": 0,
             "position": 17,

--- a/integrations/llama_index/tests/test_toolkit.py
+++ b/integrations/llama_index/tests/test_toolkit.py
@@ -155,7 +155,7 @@ def test_uc_function_to_llama_tool(client):
         # Validate passthrough of LlamaIndex argument
         assert tool.metadata.return_direct
 
-        result = json.loads(tool.fn(x="some_string"))["value"]
+        result = json.loads(tool.fn(properties={"x": "some_string"}))["value"]
         assert result == "some_string"
 
 
@@ -170,7 +170,7 @@ def test_toolkit_with_invalid_function_input(client):
         mock.patch.object(client, "get_function", return_value=mock_function_info),
     ):
         # Test with invalid input params that are not matching expected schema
-        invalid_inputs = {"unexpected_key": "value"}
+        invalid_inputs = {"properties": {"unexpected_key": "value"}}
         tool = UCFunctionToolkit.uc_function_to_llama_tool(
             function_name="catalog.schema.test", client=client, return_direct=True
         )


### PR DESCRIPTION
LlamaIndex requires the pydantic model definition to be passed for parameter signature validation, rather than an instance. This PR updates the logic to pass the correct type. 