### PR TITLE
add warnings for docstrings formatting

### DIFF
--- a/src/ucai/core/utils/callable_utils.py
+++ b/src/ucai/core/utils/callable_utils.py
@@ -1,8 +1,9 @@
 import ast
 import inspect
+import warnings
 from dataclasses import dataclass
 from textwrap import dedent, indent
-from typing import Any, Callable, Optional, Union, get_args, get_origin, get_type_hints
+from typing import Any, Callable, Optional, Set, Union, get_args, get_origin, get_type_hints
 
 from ucai.core.utils.type_utils import python_type_to_sql_type
 
@@ -374,6 +375,9 @@ def generate_sql_function_body(
         raise ValueError(f"Function '{func_name}' must have a docstring with a description.")
     docstring_info = parse_docstring(docstring)
 
+    params_in_signature = set(signature.parameters.keys()) - set(FORBIDDEN_PARAMS)
+    check_docstring_signature_consistency(docstring_info.params, params_in_signature, func_name)
+
     sql_params = []
     for param_name, param in signature.parameters.items():
         sql_param = process_parameter(param_name, param, type_hints, docstring_info)
@@ -428,3 +432,49 @@ def validate_return_type(func_name: str, type_hints: dict[str, Any]) -> str:
 
         raise ValueError(base_msg) from e
     return sql_return_type
+
+
+def check_docstring_signature_consistency(
+    doc_params: Optional[dict[str, str]], signature_params: Set[str], func_name: str
+) -> None:
+    """
+    Checks for inconsistencies between docstring parameters and function signature parameters.
+    Issues warnings if there are mismatches.
+
+    Args:
+        doc_params (Optional[dict[str, str]]): Parameters documented in the docstring.
+        signature_params (Set[str]): Parameters present in the function signature.
+        func_name (str): The name of the function being checked.
+
+    Returns:
+        None
+    """
+    params_in_doc = set(doc_params.keys()) if doc_params else set()
+    params_in_signature = signature_params
+
+    extra_in_doc = params_in_doc - params_in_signature
+    extra_in_signature = params_in_signature - params_in_doc
+
+    if extra_in_doc:
+        warnings.warn(
+            f"In function '{func_name}': The following parameters are documented in the docstring but not present in the function signature: {', '.join(sorted(extra_in_doc))}",
+            UserWarning,
+        )
+
+    if extra_in_signature:
+        warnings.warn(
+            f"In function '{func_name}': The following parameters are present in the function signature but not documented in the docstring: {', '.join(sorted(extra_in_signature))}",
+            UserWarning,
+        )
+
+    if doc_params and not signature_params:
+        warnings.warn(
+            f"In function '{func_name}': Docstring defines parameters, but the function has no parameters in its signature.",
+            UserWarning,
+        )
+
+    if not doc_params and signature_params:
+        warnings.warn(
+            f"In function '{func_name}': Function has parameters in its signature, but the docstring does not document any parameters.",
+            UserWarning,
+        )

--- a/src/ucai/core/utils/callable_utils.py
+++ b/src/ucai/core/utils/callable_utils.py
@@ -459,22 +459,26 @@ def check_docstring_signature_consistency(
         warnings.warn(
             f"In function '{func_name}': The following parameters are documented in the docstring but not present in the function signature: {', '.join(sorted(extra_in_doc))}",
             UserWarning,
+            stacklevel=2,
         )
 
     if extra_in_signature:
         warnings.warn(
             f"In function '{func_name}': The following parameters are present in the function signature but not documented in the docstring: {', '.join(sorted(extra_in_signature))}",
             UserWarning,
+            stacklevel=2,
         )
 
     if doc_params and not signature_params:
         warnings.warn(
             f"In function '{func_name}': Docstring defines parameters, but the function has no parameters in its signature.",
             UserWarning,
+            stacklevel=2,
         )
 
     if not doc_params and signature_params:
         warnings.warn(
             f"In function '{func_name}': Function has parameters in its signature, but the docstring does not document any parameters.",
             UserWarning,
+            stacklevel=2,
         )

--- a/src/ucai/core/utils/callable_utils.py
+++ b/src/ucai/core/utils/callable_utils.py
@@ -449,20 +449,17 @@ def check_docstring_signature_consistency(
     Returns:
         None
     """
-    params_in_doc = set(doc_params.keys()) if doc_params else set()
+    params_in_doc = set(doc_params.keys() or {})
     params_in_signature = signature_params
 
-    extra_in_doc = params_in_doc - params_in_signature
-    extra_in_signature = params_in_signature - params_in_doc
-
-    if extra_in_doc:
+    if extra_in_doc := params_in_doc - params_in_signature:
         warnings.warn(
             f"In function '{func_name}': The following parameters are documented in the docstring but not present in the function signature: {', '.join(sorted(extra_in_doc))}",
             UserWarning,
             stacklevel=2,
         )
 
-    if extra_in_signature:
+    if extra_in_signature := params_in_signature - params_in_doc:
         warnings.warn(
             f"In function '{func_name}': The following parameters are present in the function signature but not documented in the docstring: {', '.join(sorted(extra_in_signature))}",
             UserWarning,

--- a/src/ucai/core/utils/callable_utils.py
+++ b/src/ucai/core/utils/callable_utils.py
@@ -450,16 +450,15 @@ def check_docstring_signature_consistency(
         None
     """
     params_in_doc = set(doc_params.keys() or {})
-    params_in_signature = signature_params
 
-    if extra_in_doc := params_in_doc - params_in_signature:
+    if extra_in_doc := params_in_doc - signature_params:
         warnings.warn(
             f"In function '{func_name}': The following parameters are documented in the docstring but not present in the function signature: {', '.join(sorted(extra_in_doc))}",
             UserWarning,
             stacklevel=2,
         )
 
-    if extra_in_signature := params_in_signature - params_in_doc:
+    if extra_in_signature := signature_params - params_in_doc:
         warnings.warn(
             f"In function '{func_name}': The following parameters are present in the function signature but not documented in the docstring: {', '.join(sorted(extra_in_signature))}",
             UserWarning,

--- a/tests/core/test_callable_utils.py
+++ b/tests/core/test_callable_utils.py
@@ -12,7 +12,12 @@ from ucai.core.utils.callable_utils import generate_sql_function_body
 
 def test_simple_function_no_docstring():
     def simple_func(a: int, b: int) -> int:
-        """Simple addition"""
+        """
+        Simple addition
+        Args:
+            a: Parameter a
+            b: Parameter b
+        """
         return a + b
 
     sql_body = generate_sql_function_body(simple_func, "test_catalog", "test_schema", True)
@@ -155,7 +160,7 @@ $$;
     assert sql_body.strip() == expected_sql.strip()
 
 
-def test_function_with_extra_docstring_params_ignored():
+def test_function_with_extra_docstring_params_ignored(recwarn):
     def func_with_extra_param_in_docstring(a: int) -> str:
         """
         A function with extra parameter in docstring.
@@ -185,6 +190,12 @@ $$;
     """
 
     assert sql_body.strip() == expected_sql.strip()
+    assert len(recwarn) == 1
+    warn = recwarn.pop(UserWarning)
+    assert (
+        "The following parameters are documented in the docstring but not present in the function signature: b"
+        in str(warn.message)
+    )
 
 
 # ---------------------------
@@ -404,7 +415,11 @@ $$;
 
 def test_function_with_multiple_return_paths():
     def multiple_return_func(a: int) -> str:
-        """A function with multiple return paths."""
+        """
+        A function with multiple return paths.
+        Args:
+            a: An integer
+        """
         if a > 0:
             return "Positive"
         else:
@@ -413,7 +428,7 @@ def test_function_with_multiple_return_paths():
     sql_body = generate_sql_function_body(multiple_return_func, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.multiple_return_func(a INTEGER COMMENT 'Parameter a')
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.multiple_return_func(a INTEGER COMMENT 'An integer')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with multiple return paths.'
@@ -912,7 +927,12 @@ def test_function_with_unsupported_return_type():
 
 def test_function_with_unsupported_param_type():
     def unsupported_param_type_func(a: object) -> str:
-        """Unsupported type hint"""
+        """
+        Unsupported type hint
+
+        Args:
+            a: An object
+        """
         return str(a)
 
     with pytest.raises(ValueError, match="Error in parameter 'a'"):
@@ -921,7 +941,12 @@ def test_function_with_unsupported_param_type():
 
 def test_function_without_return_type_hints():
     def no_return_type_hint_func(a: int, b: int):
-        """No return type hint"""
+        """
+        No return type hint
+        Args:
+            a: First integer
+            b: Second integer
+        """
         return a + b
 
     with pytest.raises(
@@ -932,7 +957,13 @@ def test_function_without_return_type_hints():
 
 def test_function_without_arg_type_hints():
     def no_arg_type_hint_func(a, b) -> int:
-        """No arg type hints"""
+        """
+        No arg type hints
+
+        Args:
+            a: First integer
+            b: Second integer
+        """
         return a + b
 
     with pytest.raises(ValueError, match="Missing type hint for parameter: a"):
@@ -1124,6 +1155,9 @@ def test_parameter_with_default_list():
     def func_with_default_list(a: List[int] = [1, 2, 3]) -> int:  # noqa: B006
         """
         Function with a default list parameter.
+
+        Args:
+            a: The list parameter
         """
         return sum(a)
 
@@ -1135,6 +1169,9 @@ def test_parameter_with_default_dict():
     def func_with_default_dict(a: Dict[str, int] = {"one": 1}) -> int:  # noqa: B006
         """
         Function with a default dict parameter.
+
+        Args:
+            a: The dictionary parameter
         """
         return a["one"]
 
@@ -1146,6 +1183,9 @@ def test_parameter_with_default_tuple():
     def func_with_default_tuple(a: Tuple[int] = (1, 2)) -> int:
         """
         Function with a default tuple parameter.
+
+        Args:
+            a: The tuple parameter
         """
         return sum(a)
 
@@ -1162,6 +1202,9 @@ def test_parameter_with_disallowed_scalar_default():
     def func_with_wrong_default(a: int = "10") -> int:
         """
         Function with a wrong type default parameter.
+
+        Args:
+            a: The integer parameter
         """
         return a * 2
 
@@ -1180,7 +1223,12 @@ def test_function_with_self():
     """Test that functions using 'self' raise an exception."""
 
     def func_with_self(self, a: int) -> int:
-        """Example function with 'self'."""
+        """
+        Example function with 'self'.
+
+        Args:
+            a: The integer parameter
+        """
         return a * 2
 
     with pytest.raises(
@@ -1193,7 +1241,12 @@ def test_function_with_cls():
     """Test that functions using 'cls' raise an exception."""
 
     def func_with_cls(cls, a: int) -> int:
-        """Example function with 'cls'."""
+        """
+        Example function with 'cls'.
+
+        Args:
+            a: The integer parameter
+        """
         return a + 5
 
     with pytest.raises(
@@ -1209,7 +1262,12 @@ def test_function_with_cls():
 
 def test_function_with_args():
     def func_with_args(*args) -> int:
-        """Function that incorrectly uses *args."""
+        """
+        Function that incorrectly uses *args.
+
+        Args:
+            args: Additional positional arguments
+        """
         return sum(args)
 
     with pytest.raises(
@@ -1223,7 +1281,12 @@ def test_function_with_args():
 
 def test_function_with_kwargs():
     def func_with_kwargs(**kwargs) -> int:
-        """Function that incorrectly uses **kwargs."""
+        """
+        Function that incorrectly uses **kwargs.
+
+        Args:
+            kwargs: Additional keyword arguments
+        """
         return sum(kwargs.values())
 
     with pytest.raises(
@@ -1237,7 +1300,14 @@ def test_function_with_kwargs():
 
 def test_function_with_mixed_args():
     def func_with_mixed(a: int, *args, **kwargs) -> int:
-        """Function that incorrectly uses both *args and **kwargs."""
+        """
+        Function that incorrectly uses both *args and **kwargs.
+
+        Args:
+            a: The first parameter
+            args: Additional positional arguments
+            kwargs: Additional keyword arguments
+        """
         return a + sum(args) + sum(kwargs.values())
 
     with pytest.raises(
@@ -1327,3 +1397,121 @@ AS $$
 $$;
     """
     assert sql_body.strip() == expected_sql.strip()
+
+
+# ---------------------------
+# Tests for Warning Logic
+# ---------------------------
+
+
+def test_warning_extra_params_in_docstring(recwarn):
+    def func_with_extra_doc_params(a: int) -> str:
+        """
+        Function with extra parameters in docstring.
+
+        Args:
+            a: The integer parameter.
+            b: Extra parameter not in function signature.
+
+        Returns:
+            str: The string representation of 'a'.
+        """
+        return str(a)
+
+    generate_sql_function_body(func_with_extra_doc_params, "test_catalog", "test_schema")
+
+    assert len(recwarn) == 1
+    warn = recwarn.pop(UserWarning)
+    assert (
+        "The following parameters are documented in the docstring but not present in the function signature: b"
+        in str(warn.message)
+    )
+
+
+def test_warning_missing_params_in_docstring(recwarn):
+    def func_with_missing_doc_params(a: int, b: str) -> str:
+        """
+        Function with missing parameters in docstring.
+
+        Args:
+            a: The integer parameter.
+
+        Returns:
+            str: The string representation of 'a' and 'b'.
+        """
+        return f"{a}-{b}"
+
+    generate_sql_function_body(func_with_missing_doc_params, "test_catalog", "test_schema")
+
+    assert len(recwarn) == 1
+    warn = recwarn.pop(UserWarning)
+    assert (
+        "The following parameters are present in the function signature but not documented in the docstring: b"
+        in str(warn.message)
+    )
+
+
+def test_warning_doc_params_but_no_signature_params(recwarn):
+    def func_with_doc_params_but_no_signature() -> str:
+        """
+        Function with docstring parameters but no signature parameters.
+
+        Args:
+            a: The parameter which does not exist in the signature.
+
+        Returns:
+            str: A default string.
+        """
+        return "default"
+
+    generate_sql_function_body(func_with_doc_params_but_no_signature, "test_catalog", "test_schema")
+
+    assert len(recwarn) == 2
+
+    warning_messages = [str(warn.message) for warn in recwarn.list]
+
+    expected_warning_1 = "In function 'func_with_doc_params_but_no_signature': The following parameters are documented in the docstring but not present in the function signature: a"
+    expected_warning_2 = "In function 'func_with_doc_params_but_no_signature': Docstring defines parameters, but the function has no parameters in its signature."
+
+    assert expected_warning_1 in warning_messages
+    assert expected_warning_2 in warning_messages
+
+
+def test_warning_signature_params_but_no_doc_params(recwarn):
+    def func_with_signature_params_but_no_doc(a: int, b: int) -> int:
+        """
+        Function with signature parameters but no docstring parameters.
+
+        Returns:
+            int: The sum of 'a' and 'b'.
+        """
+        return a + b
+
+    generate_sql_function_body(func_with_signature_params_but_no_doc, "test_catalog", "test_schema")
+
+    assert len(recwarn) == 2
+    warn = recwarn.pop(UserWarning)
+
+    assert (
+        "The following parameters are present in the function signature but not documented in the docstring: a, b"
+        in str(warn.message)
+    )
+
+
+def test_no_warnings_when_consistent(recwarn):
+    def consistent_func(a: int, b: str) -> str:
+        """
+        Consistent function.
+
+        Args:
+            a: The integer parameter.
+            b: The string parameter.
+
+        Returns:
+            str: The concatenation of 'a' and 'b'.
+        """
+        return f"{a}-{b}"
+
+    generate_sql_function_body(consistent_func, "test_catalog", "test_schema")
+
+    assert len(recwarn) == 0

--- a/tests/core/test_databricks_client.py
+++ b/tests/core/test_databricks_client.py
@@ -881,7 +881,12 @@ def test_create_and_execute_python_function(client: DatabricksFunctionClient):
 
 def test_create_python_function_with_invalid_arguments(client: DatabricksFunctionClient):
     def invalid_func(self, x: int) -> str:
-        """Function with 'self' in the argument."""
+        """
+        Function with 'self' in the argument.
+
+        Args:
+            x: An integer to convert to a string.
+        """
         return str(x)
 
     with pytest.raises(
@@ -890,7 +895,12 @@ def test_create_python_function_with_invalid_arguments(client: DatabricksFunctio
         client.create_python_function(func=invalid_func, catalog=CATALOG, schema=SCHEMA)
 
     def another_invalid_func(cls, x: int) -> str:
-        """Function with 'cls' in the argument."""
+        """
+        Function with 'cls' in the argument.
+
+        Args:
+            x: An integer to convert to a string.
+        """
         return str(x)
 
     with pytest.raises(


### PR DESCRIPTION
Adds warnings to improperly formatted and constructed docstrings so that users can be made aware of creating a tool that is not optimal for GenAI tool usage. 