### PR TITLE
Map python int to LONG in SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The `create_python_function` API allows you to directly convert a Python functio
 
     | Python Type          | Unity Catalog Type       |
     |----------------------|--------------------------|
-    | `int`                | `INTEGER`                |
+    | `int`                | `LONG`                   |
     | `float`              | `DOUBLE`                 |
     | `str`                | `STRING`                 |
     | `bool`               | `BOOLEAN`                |
@@ -192,7 +192,7 @@ def func_with_optional_param(a: Optional[int] = None, b: str = "default") -> str
 
 # This will be converted into the following SQL function:
 # CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_optional_param(
-#     a INTEGER DEFAULT NULL COMMENT 'Optional integer parameter, default None.',
+#     a LONG DEFAULT NULL COMMENT 'Optional integer parameter, default None.',
 #     b STRING DEFAULT 'default' COMMENT 'Optional string parameter, default "default".'
 # )
 # RETURNS STRING
@@ -222,7 +222,7 @@ def func_with_direct_default(a: int = 10, b: str = "hello") -> str:
 
 # This will be converted into the following SQL function:
 # CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_direct_default(
-#     a INTEGER DEFAULT 10 COMMENT 'Optional integer parameter with default 10.',
+#     a LONG DEFAULT 10 COMMENT 'Optional integer parameter with default 10.',
 #     b STRING DEFAULT 'hello' COMMENT 'Optional string parameter with default "hello".'
 # )
 # RETURNS STRING

--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -231,7 +231,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
 
             | Python Type          | Unity Catalog Type       |
             |----------------------|--------------------------|
-            | `int`                | `INTEGER`                |
+            | `int`                | `LONG`                |
             | `float`              | `DOUBLE`                 |
             | `str`                | `STRING`                 |
             | `bool`               | `BOOLEAN`                |

--- a/src/ucai/core/utils/type_utils.py
+++ b/src/ucai/core/utils/type_utils.py
@@ -3,7 +3,7 @@ import decimal
 from typing import Any, get_args, get_origin
 
 PYTHON_TO_SQL_TYPE_MAPPING = {
-    int: "INTEGER",
+    int: "LONG",
     float: "DOUBLE",
     str: "STRING",
     bool: "BOOLEAN",
@@ -113,7 +113,7 @@ def python_type_to_sql_type(py_type: Any) -> str:
         py_type: The Python type to be converted (e.g., List[int], Dict[str, List[int]]).
 
     Returns:
-        str: The corresponding SQL type (e.g., ARRAY<MAP<STRING, INTEGER>>).
+        str: The corresponding SQL type (e.g., ARRAY<MAP<STRING, LONG>>).
 
     Raises:
         ValueError: If the type cannot be mapped to a SQL type.

--- a/tests/core/test_callable_utils.py
+++ b/tests/core/test_callable_utils.py
@@ -432,7 +432,7 @@ def test_function_with_multiple_return_paths():
     sql_body = generate_sql_function_body(multiple_return_func, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.multiple_return_func(a LONG COMMENT 'Parameter a')
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.multiple_return_func(a LONG COMMENT 'An integer')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with multiple return paths.'

--- a/tests/core/test_callable_utils.py
+++ b/tests/core/test_callable_utils.py
@@ -18,8 +18,8 @@ def test_simple_function_no_docstring():
     sql_body = generate_sql_function_body(simple_func, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.simple_func(a INTEGER COMMENT 'Parameter a', b INTEGER COMMENT 'Parameter b')
-RETURNS INTEGER
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.simple_func(a LONG COMMENT 'Parameter a', b LONG COMMENT 'Parameter b')
+RETURNS LONG
 LANGUAGE PYTHON
 COMMENT 'Simple addition'
 AS $$
@@ -49,7 +49,7 @@ def test_function_with_multiline_docstring():
     sql_body = generate_sql_function_body(multiline_docstring_func, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.multiline_docstring_func(a INTEGER COMMENT 'The first number', b INTEGER COMMENT 'The second number')
+CREATE FUNCTION test_catalog.test_schema.multiline_docstring_func(a LONG COMMENT 'The first number', b LONG COMMENT 'The second number')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with a multiline docstring. This docstring spans multiple lines and describes the function in detail.'
@@ -82,8 +82,8 @@ def test_function_with_detailed_docstring():
     sql_body = generate_sql_function_body(detailed_func, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.detailed_func(a INTEGER COMMENT 'The first number', b INTEGER COMMENT 'The second number')
-RETURNS INTEGER
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.detailed_func(a LONG COMMENT 'The first number', b LONG COMMENT 'The second number')
+RETURNS LONG
 LANGUAGE PYTHON
 COMMENT 'A detailed function example.'
 AS $$
@@ -112,7 +112,7 @@ def test_function_with_google_docstring():
     sql_body = generate_sql_function_body(my_function, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.my_function(a INTEGER COMMENT 'The integer to add to.', b STRING COMMENT 'The string to get the length of.')
+CREATE FUNCTION test_catalog.test_schema.my_function(a LONG COMMENT 'The integer to add to.', b STRING COMMENT 'The string to get the length of.')
 RETURNS DOUBLE
 LANGUAGE PYTHON
 COMMENT 'This function adds the length of a string to an integer.'
@@ -144,7 +144,7 @@ def test_function_with_multiline_argument_description():
     )
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.my_multiline_arg_function(a INTEGER COMMENT 'The first argument, which is an integer. The integer is guaranteed to be positive.', b STRING COMMENT 'The second argument, which is a string. The string should be more than 100 characters long.')
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.my_multiline_arg_function(a LONG COMMENT 'The first argument, which is an integer. The integer is guaranteed to be positive.', b STRING COMMENT 'The second argument, which is a string. The string should be more than 100 characters long.')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'This function has a multi-line argument list.'
@@ -175,7 +175,7 @@ def test_function_with_extra_docstring_params_ignored():
     )
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.func_with_extra_param_in_docstring(a INTEGER COMMENT 'The first argument')
+CREATE FUNCTION test_catalog.test_schema.func_with_extra_param_in_docstring(a LONG COMMENT 'The first argument')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with extra parameter in docstring.'
@@ -213,7 +213,7 @@ def test_function_with_nested():
     sql_body = generate_sql_function_body(outer_func, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.outer_func(x INTEGER COMMENT 'The x parameter', y INTEGER COMMENT 'The y parameter')
+CREATE FUNCTION test_catalog.test_schema.outer_func(x LONG COMMENT 'The x parameter', y LONG COMMENT 'The y parameter')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function that demonstrates nested functions.'
@@ -252,7 +252,7 @@ def test_function_with_class():
     sql_body = generate_sql_function_body(func_with_class, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_class(a INTEGER COMMENT 'The parameter a')
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_class(a LONG COMMENT 'The parameter a')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function that defines a class inside.'
@@ -288,7 +288,7 @@ def test_function_with_lambda():
     sql_body = generate_sql_function_body(lambda_func, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.lambda_func(x INTEGER COMMENT 'The input value')
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.lambda_func(x LONG COMMENT 'The input value')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with a lambda expression.'
@@ -317,7 +317,7 @@ def test_function_with_heavily_nested_structure():
     sql_body = generate_sql_function_body(func_with_heavily_nested, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.func_with_heavily_nested(a ARRAY<MAP<STRING, ARRAY<MAP<STRING, INTEGER>>>> COMMENT 'A list of dictionaries where the key is a string and the value is a list of dictionaries with string keys and integer values.')
+CREATE FUNCTION test_catalog.test_schema.func_with_heavily_nested(a ARRAY<MAP<STRING, ARRAY<MAP<STRING, LONG>>>> COMMENT 'A list of dictionaries where the key is a string and the value is a list of dictionaries with string keys and integer values.')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function that accepts a heavily nested structure of lists and dictionaries.'
@@ -352,8 +352,8 @@ def test_function_with_decorator():
     sql_body = generate_sql_function_body(decorated_func, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.decorated_func(a INTEGER COMMENT 'First integer', b INTEGER COMMENT 'Second integer')
-RETURNS INTEGER
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.decorated_func(a LONG COMMENT 'First integer', b LONG COMMENT 'Second integer')
+RETURNS LONG
 LANGUAGE PYTHON
 COMMENT 'A static method decorated function.'
 AS $$
@@ -388,8 +388,8 @@ def test_function_with_try_except():
     sql_body = generate_sql_function_body(try_except_func, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.try_except_func(a INTEGER COMMENT 'First number', b INTEGER COMMENT 'Second number')
-RETURNS INTEGER
+CREATE FUNCTION test_catalog.test_schema.try_except_func(a LONG COMMENT 'First number', b LONG COMMENT 'Second number')
+RETURNS LONG
 LANGUAGE PYTHON
 COMMENT 'A function with try-except block.'
 AS $$
@@ -413,7 +413,7 @@ def test_function_with_multiple_return_paths():
     sql_body = generate_sql_function_body(multiple_return_func, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.multiple_return_func(a INTEGER COMMENT 'Parameter a')
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.multiple_return_func(a LONG COMMENT 'Parameter a')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with multiple return paths.'
@@ -506,7 +506,7 @@ def test_function_with_list_input():
     sql_body = generate_sql_function_body(func_with_list, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_list(a ARRAY<INTEGER> COMMENT 'A list of integers')
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_list(a ARRAY<LONG> COMMENT 'A list of integers')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function that accepts a list of integers.'
@@ -533,7 +533,7 @@ def test_function_with_map_input():
     sql_body = generate_sql_function_body(func_with_map, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.func_with_map(a MAP<STRING, INTEGER> COMMENT 'A map with string keys and integer values')
+CREATE FUNCTION test_catalog.test_schema.func_with_map(a MAP<STRING, LONG> COMMENT 'A map with string keys and integer values')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function that accepts a map with string keys and integer values.'
@@ -587,7 +587,7 @@ def test_function_with_list_of_dict_input():
     sql_body = generate_sql_function_body(func_with_list_of_map, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.func_with_list_of_map(a ARRAY<MAP<STRING, INTEGER>> COMMENT 'A list of maps with string keys and integer values')
+CREATE FUNCTION test_catalog.test_schema.func_with_list_of_map(a ARRAY<MAP<STRING, LONG>> COMMENT 'A list of maps with string keys and integer values')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function that accepts a list of maps with string keys and integer values.'
@@ -619,7 +619,7 @@ def test_function_with_list_return():
 
     expected_sql = """
 CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_list_return()
-RETURNS ARRAY<INTEGER>
+RETURNS ARRAY<LONG>
 LANGUAGE PYTHON
 COMMENT 'A function that returns a list of integers.'
 AS $$
@@ -643,7 +643,7 @@ def test_function_with_map_return():
 
     expected_sql = """
 CREATE FUNCTION test_catalog.test_schema.func_with_map_return()
-RETURNS MAP<STRING, INTEGER>
+RETURNS MAP<STRING, LONG>
 LANGUAGE PYTHON
 COMMENT 'A function that returns a map with string keys and integer values.'
 AS $$
@@ -962,7 +962,7 @@ def test_function_with_optional_default_values():
     sql_body = generate_sql_function_body(func_with_optional, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.func_with_optional(a INTEGER COMMENT 'Required integer.', b INTEGER DEFAULT 10 COMMENT 'Optional integer with default 10.', c STRING DEFAULT 'default' COMMENT 'Optional string with default "default".')
+CREATE FUNCTION test_catalog.test_schema.func_with_optional(a LONG COMMENT 'Required integer.', b LONG DEFAULT 10 COMMENT 'Optional integer with default 10.', c STRING DEFAULT 'default' COMMENT 'Optional string with default "default".')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function that demonstrates optional parameters with default values.'
@@ -991,8 +991,8 @@ def test_function_with_mixed_required_and_default_values():
     sql_body = generate_sql_function_body(func_with_mixed, "test_catalog", "test_schema", True)
 
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_mixed(a INTEGER COMMENT 'Required parameter.', b INTEGER DEFAULT 5 COMMENT 'Optional parameter with default value 5.', c INTEGER DEFAULT 20 COMMENT 'Optional parameter with default value 20.')
-RETURNS INTEGER
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.func_with_mixed(a LONG COMMENT 'Required parameter.', b LONG DEFAULT 5 COMMENT 'Optional parameter with default value 5.', c LONG DEFAULT 20 COMMENT 'Optional parameter with default value 20.')
+RETURNS LONG
 LANGUAGE PYTHON
 COMMENT 'A function with both required and optional parameters.'
 AS $$
@@ -1076,7 +1076,7 @@ def test_function_with_default_numeric_and_string():
     )
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.func_with_numeric_and_string(a INTEGER DEFAULT 5 COMMENT 'Optional integer with default value 5.', b STRING DEFAULT 'foo' COMMENT 'Optional string with default value "foo".')
+CREATE FUNCTION test_catalog.test_schema.func_with_numeric_and_string(a LONG DEFAULT 5 COMMENT 'Optional integer with default value 5.', b STRING DEFAULT 'foo' COMMENT 'Optional string with default value "foo".')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with both numeric and string default parameters.'
@@ -1104,7 +1104,7 @@ def test_function_with_optional_parameter():
     sql_body = generate_sql_function_body(func_with_optional_param, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.func_with_optional_param(a INTEGER DEFAULT NULL COMMENT 'Optional integer parameter, default None.', b STRING DEFAULT 'default' COMMENT 'Optional string parameter, default "default".')
+CREATE FUNCTION test_catalog.test_schema.func_with_optional_param(a LONG DEFAULT NULL COMMENT 'Optional integer parameter, default None.', b STRING DEFAULT 'default' COMMENT 'Optional string parameter, default "default".')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with an optional integer parameter and a string parameter.'
@@ -1279,7 +1279,7 @@ def test_function_with_2_space_indentation():
 
     # Expected SQL with 2-space indentation for function body and nested function
     expected_sql = """
-CREATE OR REPLACE FUNCTION test_catalog.test_schema.two_space_indented_func(a INTEGER COMMENT 'The parameter')
+CREATE OR REPLACE FUNCTION test_catalog.test_schema.two_space_indented_func(a LONG COMMENT 'The parameter')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function with 2-space indentation.'
@@ -1316,7 +1316,7 @@ def test_function_with_imports():
     sql_body = generate_sql_function_body(func_with_import, "test_catalog", "test_schema")
 
     expected_sql = """
-CREATE FUNCTION test_catalog.test_schema.func_with_import(a INTEGER COMMENT 'The input parameter')
+CREATE FUNCTION test_catalog.test_schema.func_with_import(a LONG COMMENT 'The input parameter')
 RETURNS STRING
 LANGUAGE PYTHON
 COMMENT 'A function that imports a module and returns a result.'


### PR DESCRIPTION
INTEGER has limitation of 4-byte signed integer numbers, but python int can be larger than that, so we map python int to SQL LONG type, which is 8-byte signed integer number (biggest range SQL can hold)