### PR TITLE
Add client session refresh logic

### DIFF
--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -93,7 +93,7 @@ def _is_in_databricks_notebook_environment() -> bool:
     try:
         from dbruntime.databricks_repl_context import get_context
 
-        return get_context().isInNotebook()
+        return get_context().isInNotebook
     except (ImportError, AttributeError):
         return False
 

--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -94,7 +94,7 @@ def _is_in_databricks_notebook_environment() -> bool:
         from dbruntime.databricks_repl_context import get_context
 
         return get_context().isInNotebook
-    except (ImportError, AttributeError):
+    except Exception:
         return False
 
 
@@ -141,7 +141,6 @@ def retry_on_session_expiration(func):
                 if SESSION_EXCEPTION_MESSAGE in error_message:
                     if not self._is_default_client:
                         refresh_message = f"Failed to execute {func.__name__} due to session expiration. Unable to automatically refresh session when using a custom client."
-                        _logger.error(refresh_message)
                         raise RuntimeError(refresh_message) from e
 
                     if attempt < max_attempts:
@@ -157,7 +156,6 @@ def retry_on_session_expiration(func):
                         continue
                     else:
                         refresh_failure_message = f"Failed to execute {func.__name__} after {max_attempts} attempts due to session expiration."
-                        _logger.error(refresh_failure_message)
                         raise RuntimeError(refresh_failure_message) from e
                 else:
                     raise

--- a/src/ucai/core/databricks.py
+++ b/src/ucai/core/databricks.py
@@ -654,6 +654,11 @@ class DatabricksFunctionClient(BaseFunctionClient):
                     format="CSV", value=csv_buffer.getvalue(), truncated=truncated
                 )
         except Exception as e:
+            if (
+                "session_id is no longer usable"
+                or "BAD_REQUEST: session_id is no longer usable" in str(e)
+            ):
+                raise
             raise RuntimeError(
                 f"Failed to execute function with function name: {function_info.full_name}"
             ) from e

--- a/src/ucai/core/envs/databricks_env_vars.py
+++ b/src/ucai/core/envs/databricks_env_vars.py
@@ -52,3 +52,9 @@ UCAI_DATABRICKS_SERVERLESS_EXECUTION_RESULT_ROW_LIMIT = _EnvironmentVariable(
     "100",
     "Maximum number of rows of the function execution result using Databricks client with serverless.",
 )
+
+UCAI_DATABRICKS_SESSION_RETRY_MAX_ATTEMPTS = _EnvironmentVariable(
+    "UCAI_DATABRICKS_SESSION_RETRY_MAX_ATTEMPTS",
+    "5",
+    "Maximum number of attempts to retry refreshing the session client in case of token expiry.",
+)


### PR DESCRIPTION
Adds retry logic for the two primary mechanism of token expiry and refreshes the connections that the client may make to re-fetch the auth tokens needed. 
Services mocked in tests.